### PR TITLE
Install from remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LLM Cmd 2 iterates on the original package:
 1. First, install the [llm CLI tool](https://github.com/simonw/llm)
 2. Run the installation script:
    ```bash
-   ./install.sh
+   curl -fsSL https://raw.githubusercontent.com/tombedor/llm-cmd2/refs/heads/main/install.sh | /bin/bash
    ```
 3. Restart your terminal or run:
    ```bash

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,12 @@ echo "✓ llm CLI found"
 
 # Copy the script to home directory
 HOME_SCRIPT="$HOME/.llm-cmd"
-cp .llm-cmd2 "$HOME_SCRIPT"
+# Check if we are running from within repository or remotely
+if [[ ! -f ".llm-cmd2" ]];
+    curl -o "$HOME_SCRIPT" -fsSL https://raw.githubusercontent.com/tombedor/llm-cmd2/refs/heads/main/.llm-cmd2
+else 
+    cp .llm-cmd2 "$HOME_SCRIPT"
+fi
 echo "✓ Copied script to $HOME_SCRIPT"
 
 # Check if .zshrc exists, create if it doesn't

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ echo "✓ llm CLI found"
 # Copy the script to home directory
 HOME_SCRIPT="$HOME/.llm-cmd"
 # Check if we are running from within repository or remotely
-if [[ ! -f ".llm-cmd2" ]];
+if [[ ! -f ".llm-cmd2" ]]; then
     curl -o "$HOME_SCRIPT" -fsSL https://raw.githubusercontent.com/tombedor/llm-cmd2/refs/heads/main/.llm-cmd2
 else 
     cp .llm-cmd2 "$HOME_SCRIPT"


### PR DESCRIPTION
Allow to install llmcmd from remote GitHub. This simplifies installation accessibility.